### PR TITLE
カレンダーのプログラム(Ruby)

### DIFF
--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -4,19 +4,8 @@ require 'date'
 require 'optparse'
 
 params = ARGV.getopts('y:', 'm:')
-
-if params['y']
-  year = params['y'].to_i
-else
-  year = Date.today.year
-end
-
-if params['m']
-  month = params['m'].to_i
-else
-  month = Date.today.month
-end
-
+year = params['y'] ? params['y'].to_i : Date.today.year
+month = params['m'] ? params['m'].to_i : Date.today.month
 
 day = Date.new(year, month)
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -11,18 +11,18 @@ day = Date.new(year, month)
 
 puts day.strftime("%m月 %Y").center(20)
 puts "日 月 火 水 木 金 土"
-last_day = Date.new(day.year, day.month, -1).day
-first_day_wday = Date.new(day.year, day.month, 1).wday
-print "   " * first_day_wday
-(1..last_day).each do |day|
+first_day = Date.new(day.year, day.month, 1)
+last_day = Date.new(day.year, day.month, -1)
+print "   " * first_day.wday
+(first_day..last_day).each do |date|
   # 横並びに表示したいためputsではなくprintで出力する
-  if day <= 9
-    print " " + "#{day}" + " "
+  if date.day <= 9
+    print " " + "#{date.day}" + " "
   else
-    print "#{day}" + " "
+    print "#{date.day}" + " "
   end
 
-  if (first_day_wday + day) % 7 == 0
+  if date.saturday?
     print "\n"
   end
 end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -23,6 +23,6 @@ print "   " * first_day.wday
   end
 
   if date.saturday?
-    print "\n"
+    puts
   end
 end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -16,12 +16,8 @@ last_day = Date.new(day.year, day.month, -1)
 print "   " * first_day.wday
 (first_day..last_day).each do |date|
   # 横並びに表示したいためputsではなくprintで出力する
-  if date.day <= 9
-    print " " + "#{date.day}" + " "
-  else
-    print "#{date.day}" + " "
-  end
-
+  print "#{date.day}".rjust(2) + " "
+  
   if date.saturday?
     puts
   end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -26,3 +26,4 @@ print "   " * first_day.wday
     puts
   end
 end
+puts

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,13 +1,14 @@
 require 'date'
 
 day = Date.today
+
 puts day.strftime("%m月 %Y").center(20)
 puts "日 月 火 水 木 金 土"
 
 last_day = Date.new(day.year, day.month, -1).day
 first_day_wday = Date.new(day.year, day.month, 1).wday
 
-print " " * first_day_wday
+print "   " * first_day_wday
 
 (1..last_day).each do |day|
   # 横並びに表示したいためputsではなくprintで出力する

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,5 +1,5 @@
 require 'date'
 
 date = Date.today
-puts "#{date.month}月 #{date.year}"
+puts "#{date.strftime('%m')}月 #{date.strftime('%Y')}"
 puts "日 月 火 水 木 金 土"

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -17,7 +17,7 @@ puts " " * first_day_wday
     print "#{day}" + " "
   end
 
-  if (first_day_wday + day ) % 7 == 0
+  if (first_day_wday + day) % 7 == 0
     print "\n"
   end
 end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,17 +1,17 @@
 require 'date'
 
 day = Date.today
-puts day.strftime("%m月 %Y")
+puts day.strftime("%m月 %Y").center(20)
 puts "日 月 火 水 木 金 土"
 
 last_day = Date.new(day.year, day.month, -1).day
 first_day_wday = Date.new(day.year, day.month, 1).wday
 
-puts " " * first_day_wday
+print " " * first_day_wday
 
 (1..last_day).each do |day|
+  # 横並びに表示したいためputsではなくprintで出力する
   if day <= 9
-    # 横並びに表示したいためputsではなくprintで出力する
     print " " + "#{day}" + " "
   else
     print "#{day}" + " "

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,5 +1,6 @@
 require 'date'
 
-date = Date.today
-puts "#{date.strftime('%m')}月 #{date.strftime('%Y')}"
+day = Date.today
+puts "#{day.strftime('%m')}月 #{day.strftime('%Y')}"
 puts "日 月 火 水 木 金 土"
+

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -4,3 +4,7 @@ day = Date.today
 puts "#{day.strftime('%m')}月 #{day.strftime('%Y')}"
 puts "日 月 火 水 木 金 土"
 
+last_day = Date.new(day.year, day.month, -1).day
+(1..last_day).each do |day|
+  print day
+end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -2,3 +2,4 @@ require 'date'
 
 date = Date.today
 puts "#{date.month}月 #{date.year}"
+puts "日 月 火 水 木 金 土"

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -4,8 +4,6 @@ require 'date'
 require 'optparse'
 
 params = ARGV.getopts('y:', 'm:')
-# puts params['y']
-# puts params['m']
 
 if params['y']
   year = params['y'].to_i
@@ -19,8 +17,6 @@ else
   month = Date.today.month
 end
 
-# puts year
-# puts month
 
 day = Date.new(year, month)
 

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,0 +1,4 @@
+require 'date'
+
+date = Date.today
+puts "#{date.month}月 #{date.year}"

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,7 +1,7 @@
 require 'date'
 
 day = Date.today
-puts "#{day.strftime('%m')}月 #{day.strftime('%Y')}"
+puts "#{day.strftime("%m月 %Y")}"
 puts "日 月 火 水 木 金 土"
 
 last_day = Date.new(day.year, day.month, -1).day

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,7 +1,7 @@
 require 'date'
 
 day = Date.today
-puts "#{day.strftime("%m月 %Y")}"
+puts day.strftime("%m月 %Y")
 puts "日 月 火 水 木 金 土"
 
 last_day = Date.new(day.year, day.month, -1).day

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -5,6 +5,19 @@ puts day.strftime("%m月 %Y")
 puts "日 月 火 水 木 金 土"
 
 last_day = Date.new(day.year, day.month, -1).day
+first_day_wday = Date.new(day.year, day.month, 1).wday
+
+puts " " * first_day_wday
+
 (1..last_day).each do |day|
-  print day
+  if day <= 9
+    # 横並びに表示したいためputsではなくprintで出力する
+    print " " + "#{day}" + " "
+  else
+    print "#{day}" + " "
+  end
+
+  if (first_day_wday + day ) % 7 == 0
+    print "\n"
+  end
 end

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,17 +1,34 @@
 #!/usr/bin/env ruby
 
 require 'date'
+require 'optparse'
 
-day = Date.today
+params = ARGV.getopts('y:', 'm:')
+# puts params['y']
+# puts params['m']
+
+if params['y']
+  year = params['y'].to_i
+else
+  year = Date.today.year
+end
+
+if params['m']
+  month = params['m'].to_i
+else
+  month = Date.today.month
+end
+
+# puts year
+# puts month
+
+day = Date.new(year, month)
 
 puts day.strftime("%m月 %Y").center(20)
 puts "日 月 火 水 木 金 土"
-
 last_day = Date.new(day.year, day.month, -1).day
 first_day_wday = Date.new(day.year, day.month, 1).wday
-
 print "   " * first_day_wday
-
 (1..last_day).each do |day|
   # 横並びに表示したいためputsではなくprintで出力する
   if day <= 9

--- a/02.calendar/calendar.rb
+++ b/02.calendar/calendar.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'date'
 
 day = Date.today


### PR DESCRIPTION
# タイトル
コマンド引数を使ったカレンダープログラム

## 必須要件とテスト結果
- [x] -mで月を、-yで年を指定できる
ただし、-yのみ指定して一年分のカレンダーを表示する機能の実装は不要
<img width="345" alt="スクリーンショット 2023-10-31 22 29 41" src="https://github.com/fjordllc/ruby-practices/assets/86139603/01a69675-b0b2-4854-9647-28c1191f81b1">

- [x] 引数を指定しない場合は、今月・今年のカレンダーが表示される
<img width="356" alt="スクリーンショット 2023-10-31 22 27 24" src="https://github.com/fjordllc/ruby-practices/assets/86139603/0460da9d-0dd1-41ed-8b6a-4943f304105f">

- [x] MacやWSLに入っているcalコマンドと同じ見た目になっている
<img width="357" alt="スクリーンショット 2023-10-31 22 27 57" src="https://github.com/fjordllc/ruby-practices/assets/86139603/04229faf-a295-4c79-9f7f-90af3c7826de">

- [x] 少なくとも1970年から2100年までは正しく表示される
<img width="374" alt="スクリーンショット 2023-10-31 22 33 26" src="https://github.com/fjordllc/ruby-practices/assets/86139603/d4007aac-12db-4c3b-96e9-f5634fc97a53">

## 除外内容
以下２点については実装しておりません
- [ ] 今日の日付の部分の色が反転する(背景色と文字色が入れ替わる)
- [ ] どのような引数が与えられようが、cal コマンドと同じ表示結果になる

## Rubocop
- [x] 実行済み
- [ ] 未実行

## その他
ご確認お願いいたします