### PR TITLE
My ls option -a

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,11 +11,9 @@ def file_names(path = '.')
   opt.on('-a') { |v| params[:a] = v }
   opt.parse!(ARGV)
 
-  if params[:a]
-    Dir.entries(path).sort
-  else
-    Dir.entries(path).reject { |entry| entry.start_with?('.') }.sort
-  end
+  file_names = Dir.entries(path)
+  file_names = file_names.reject { |entry| entry.start_with?('.') } unless params[:a]
+  file_names.sort
 end
 
 def display_columns(entries)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,10 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 COLUMNS_COUNT = 3
 
 def file_names(path = '.')
-  Dir.entries(path).reject { |entry| entry.start_with?('.') }.sort
+  opt = OptionParser.new
+  params = {}
+  opt.on('-a') { |v| params[:a] = v }
+  opt.parse!(ARGV)
+
+  if params[:a]
+    Dir.entries(path).sort
+  else
+    Dir.entries(path).reject { |entry| entry.start_with?('.') }.sort
+  end
 end
 
 def display_columns(entries)


### PR DESCRIPTION
# タイトル
自作のlsコマンドに-aオプションを追加しました。

## 達成できる内容
- オプションなしで実行した場合は隠しファイルは表示されない
- オプションで`-a`を指定したら、.から始まる隠しファイルも表示できる

## テスト結果
<img width="332" alt="スクリーンショット 2024-01-15 15 36 45" src="https://github.com/funxxfun/ruby-practices/assets/86139603/0749d47d-4205-4e84-bd2d-528ff9d6cd35">


## Rubocop
- [x] 実行済み
- [ ] 未実行
<img width="353" alt="スクリーンショット 2024-01-15 15 23 32" src="https://github.com/funxxfun/ruby-practices/assets/86139603/ef0d1ef2-ff78-4939-b5c6-99e1f57ec5f7">



## その他
ご確認よろしくお願いします。