### PR TITLE
-aオプションを一旦削除して、-rオプションを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,12 +8,12 @@ COLUMNS_COUNT = 3
 def file_names(path = '.')
   opt = OptionParser.new
   params = {}
-  opt.on('-a') { |v| params[:a] = v }
+  opt.on('-r') { |v| params[:r] = v }
   opt.parse!(ARGV)
 
-  file_names = Dir.entries(path)
-  file_names = file_names.reject { |entry| entry.start_with?('.') } unless params[:a]
-  file_names.sort
+  file_names = Dir.entries(path).reject { |file_name| file_name.start_with?('.') }.sort
+  file_names = file_names.reverse if params[:r]
+  file_names
 end
 
 def display_columns(entries)


### PR DESCRIPTION
# タイトル
自作のlsコマンドに-rオプションを追加しました。

## 達成できる内容
- オプションなしで実行した場合は隠しファイルは表示されない
- オプションで`-r`を指定したら、ファイル表示順番が逆になる

## 実行結果
<img width="348" alt="スクリーンショット 2024-01-23 10 40 39" src="https://github.com/funxxfun/ruby-practices/assets/86139603/404045fe-a8b3-43f0-b4b9-76f2ad7aceef">


## Rubocop
- [x] 実行済み
- [ ] 未実行
<img width="350" alt="スクリーンショット 2024-01-23 10 37 04" src="https://github.com/funxxfun/ruby-practices/assets/86139603/c7c2132f-a099-4cb5-96fd-0aa1672d4235">


## その他
ご確認よろしくお願いします。