### PR TITLE
My ls option l

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,7 +6,7 @@ require 'etc'
 
 COLUMNS_COUNT = 3
 
-def files(path = '.', options)
+def files(options, path = '.')
   opt = OptionParser.new
   opt.on('-r') { |v| options[:r] = v }
   opt.on('-l') { |v| options[:l] = v }
@@ -30,7 +30,7 @@ def display_columns(entries)
   end
 end
 
-def transformation_file_type(file)
+def format_file_type(file)
   file_type = File.stat(file).ftype
   file_types = {
     'file' => '-',
@@ -44,27 +44,18 @@ def transformation_file_type(file)
   file_types[file_type]
 end
 
-def transformation_file_permissions(file)
-  file_permissions = file.mode.to_s(8).slice(-3, 3)
-  file_permissions = file_permissions.chars.map(&:to_i)
+def format_permissions(file)
+  file_permissions = file.mode.to_s(8).slice(-3, 3).chars.map(&:to_i)
   file_permissions = file_permissions.map do |permission|
     case permission
-    when 0
-      '---'
-    when 1
-      '--x'
-    when 2
-      '-w-'
-    when 3
-      '-wx'
-    when 4
-      'r--'
-    when 5
-      'r-x'
-    when 6
-      'rw-'
-    when 7
-      'rwx'
+    when 0 then '---'
+    when 1 then '--x'
+    when 2 then '-w-'
+    when 3 then '-wx'
+    when 4 then 'r--'
+    when 5 then 'r-x'
+    when 6 then 'rw-'
+    when 7 then 'rwx'
     end
   end
   file_permissions.join
@@ -73,8 +64,8 @@ end
 def display_long_format(entries)
   entries.each do |entry|
     file = File.stat(entry)
-    file_type = transformation_file_type(entry)
-    file_permissions = transformation_file_permissions(file)
+    file_type = format_file_type(entry)
+    file_permissions = format_permissions(file)
     file_nlink = file.nlink
     file_owner = Etc.getpwuid(file.uid).name
     file_group = Etc.getgrgid(file.gid).name
@@ -85,7 +76,7 @@ def display_long_format(entries)
 end
 
 options = {}
-entries = files('.', options)
+entries = files(options, '.')
 
 if options[:l]
   display_long_format(entries)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,6 +6,29 @@ require 'etc'
 
 COLUMNS_COUNT = 3
 
+FILE_TYPE =
+  {
+    'file' => '-',
+    'directory' => 'd',
+    'characterSpecial' => 'c',
+    'blockSpecial' => 'b',
+    'fifo' => 'p',
+    'link' => 'l',
+    'socket' => 's'
+  }.freeze
+
+FILE_PERMISSION =
+  {
+    0 => '---',
+    1 => '--x',
+    2 => '-w-',
+    3 => '-wx',
+    4 => 'r--',
+    5 => 'r-x',
+    6 => 'rw-',
+    7 => 'rwx'
+  }.freeze
+
 def files(options, path = '.')
   opt = OptionParser.new
   opt.on('-r') { |v| options[:r] = v }
@@ -32,31 +55,13 @@ end
 
 def format_file_type(file)
   file_type = File.stat(file).ftype
-  file_types = {
-    'file' => '-',
-    'directory' => 'd',
-    'characterSpecial' => 'c',
-    'blockSpecial' => 'b',
-    'fifo' => 'p',
-    'link' => 'l',
-    'socket' => 's'
-  }
-  file_types[file_type]
+  FILE_TYPE[file_type]
 end
 
 def format_permissions(file)
   file_permissions = file.mode.to_s(8).slice(-3, 3).chars.map(&:to_i)
   file_permissions = file_permissions.map do |permission|
-    case permission
-    when 0 then '---'
-    when 1 then '--x'
-    when 2 then '-w-'
-    when 3 then '-wx'
-    when 4 then 'r--'
-    when 5 then 'r-x'
-    when 6 then 'rw-'
-    when 7 then 'rwx'
-    end
+    FILE_PERMISSION[permission]
   end
   file_permissions.join
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -44,11 +44,37 @@ def transformation_file_type(file)
   file_types[file_type]
 end
 
+def transformation_file_permissions(file)
+  file_permissions = file.mode.to_s(8).slice(-3, 3)
+  file_permissions = file_permissions.chars.map(&:to_i)
+  file_permissions = file_permissions.map do |permission|
+    case permission
+    when 0
+      '---'
+    when 1
+      '--x'
+    when 2
+      '-w-'
+    when 3
+      '-wx'
+    when 4
+      'r--'
+    when 5
+      'r-x'
+    when 6
+      'rw-'
+    when 7
+      'rwx'
+    end
+  end
+  file_permissions.join
+end
+
 def display_long_format(entries)
   entries.each do |entry|
     file = File.stat(entry)
     file_type = transformation_file_type(entry)
-    file_permissions = file.mode
+    file_permissions = transformation_file_permissions(file)
     file_nlink = file.nlink
     file_owner = Etc.getpwuid(file.uid).name
     file_group = Etc.getgrgid(file.gid).name

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -5,15 +5,15 @@ require 'optparse'
 
 COLUMNS_COUNT = 3
 
-def file_names(path = '.')
+def files(path = '.', options)
   opt = OptionParser.new
-  params = {}
-  opt.on('-r') { |v| params[:r] = v }
+  opt.on('-r') { |v| options[:r] = v }
+  opt.on('-l') { |v| options[:l] = v }
   opt.parse!(ARGV)
 
-  file_names = Dir.entries(path).reject { |file_name| file_name.start_with?('.') }.sort
-  file_names = file_names.reverse if params[:r]
-  file_names
+  files = Dir.entries(path).reject { |file| file.start_with?('.') }.sort
+  files = files.reverse if options[:r]
+  files
 end
 
 def display_columns(entries)
@@ -29,4 +29,15 @@ def display_columns(entries)
   end
 end
 
-display_columns(file_names)
+def display_long(entries)
+
+end
+
+options = {}
+entries = files('.', options)
+
+if options[:l]
+  display_long(entries)
+else
+  display_columns(entries)
+end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -32,22 +32,16 @@ end
 
 def transformation_file_type(file)
   file_type = File.stat(file).ftype
-  case file_type
-  when 'file'
-    '-'
-  when 'directory'
-    'd'
-  when 'characterSpecial'
-    'c'
-  when 'blockSpecial'
-    'b'
-  when 'fifo'
-    'p'
-  when 'link'
-    'l'
-  when 'socket'
-    's'
-  end
+  file_types = {
+    'file' => '-',
+    'directory' => 'd',
+    'characterSpecial' => 'c',
+    'blockSpecial' => 'b',
+    'fifo' => 'p',
+    'link' => 'l',
+    'socket' => 's'
+  }
+  file_types[file_type]
 end
 
 def display_long_format(entries)
@@ -59,7 +53,7 @@ def display_long_format(entries)
     file_owner = Etc.getpwuid(file.uid).name
     file_group = Etc.getgrgid(file.gid).name
     file_size = file.size
-    time_stamp = file.mtime.strftime("%-m %e %H:%M")
+    time_stamp = file.mtime.strftime('%-m %e %H:%M')
     puts "#{file_type}#{file_permissions} #{file_nlink} #{file_owner} #{file_group} #{file_size} #{time_stamp} #{entry}"
   end
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -29,15 +29,25 @@ def display_columns(entries)
   end
 end
 
-def display_long(entries)
-
+def display_long_format(entries)
+  entries.each do |entry|
+    file = File.stat(entry)
+    file_type = file.ftype
+    file_permissions = file.mode
+    file_nlink = file.nlink
+    file_owner = file.uid
+    file_group = file.gid
+    file_size = file.size
+    time_stamp = file.mtime
+    puts "#{file_type}#{file_permissions} #{file_nlink} #{file_owner} #{file_group} #{file_size} #{time_stamp} #{entry}"
+  end
 end
 
 options = {}
 entries = files('.', options)
 
 if options[:l]
-  display_long(entries)
+  display_long_format(entries)
 else
   display_columns(entries)
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
 COLUMNS_COUNT = 3
 
@@ -55,8 +56,8 @@ def display_long_format(entries)
     file_type = transformation_file_type(entry)
     file_permissions = file.mode
     file_nlink = file.nlink
-    file_owner = file.uid
-    file_group = file.gid
+    file_owner = Etc.getpwuid(file.uid).name
+    file_group = Etc.getgrgid(file.gid).name
     file_size = file.size
     time_stamp = file.mtime
     puts "#{file_type}#{file_permissions} #{file_nlink} #{file_owner} #{file_group} #{file_size} #{time_stamp} #{entry}"

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -29,10 +29,30 @@ def display_columns(entries)
   end
 end
 
+def transformation_file_type(file)
+  file_type = File.stat(file).ftype
+  case file_type
+  when 'file'
+    '-'
+  when 'directory'
+    'd'
+  when 'characterSpecial'
+    'c'
+  when 'blockSpecial'
+    'b'
+  when 'fifo'
+    'p'
+  when 'link'
+    'l'
+  when 'socket'
+    's'
+  end
+end
+
 def display_long_format(entries)
   entries.each do |entry|
     file = File.stat(entry)
-    file_type = file.ftype
+    file_type = transformation_file_type(entry)
     file_permissions = file.mode
     file_nlink = file.nlink
     file_owner = file.uid

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -59,7 +59,7 @@ def display_long_format(entries)
     file_owner = Etc.getpwuid(file.uid).name
     file_group = Etc.getgrgid(file.gid).name
     file_size = file.size
-    time_stamp = file.mtime
+    time_stamp = file.mtime.strftime("%-m %e %H:%M")
     puts "#{file_type}#{file_permissions} #{file_nlink} #{file_owner} #{file_group} #{file_size} #{time_stamp} #{entry}"
   end
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -66,12 +66,12 @@ def display_long_format(entries)
     file = File.stat(entry)
     file_type = format_file_type(entry)
     file_permissions = format_permissions(file)
-    file_nlink = file.nlink
+    file_nlink = file.nlink.to_s
     file_owner = Etc.getpwuid(file.uid).name
     file_group = Etc.getgrgid(file.gid).name
-    file_size = file.size
+    file_size = file.size.to_s
     time_stamp = file.mtime.strftime('%-m %e %H:%M')
-    puts "#{file_type}#{file_permissions} #{file_nlink} #{file_owner} #{file_group} #{file_size} #{time_stamp} #{entry}"
+    puts "#{file_type}#{file_permissions} #{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} #{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -67,6 +67,12 @@ def format_permissions(file)
 end
 
 def display_long_format(entries)
+  block_sizes = entries.map do |entry|
+    file_stat = File.stat(entry)
+    file_stat.blocks
+  end
+  total_blocks = block_sizes.sum
+  puts "total #{total_blocks}"
   entries.each do |entry|
     file = File.stat(entry)
     file_type = format_file_type(entry)
@@ -77,8 +83,8 @@ def display_long_format(entries)
     file_size = file.size.to_s
     time_stamp = file.mtime.strftime('%-m %e %H:%M')
     puts "#{file_type}#{file_permissions} " \
-         "#{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} " \
-         "#{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
+    "#{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} " \
+    "#{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -76,7 +76,9 @@ def display_long_format(entries)
     file_group = Etc.getgrgid(file.gid).name
     file_size = file.size.to_s
     time_stamp = file.mtime.strftime('%-m %e %H:%M')
-    puts "#{file_type}#{file_permissions} #{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} #{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
+    puts "#{file_type}#{file_permissions} " \
+         "#{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} " \
+         "#{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
   end
 end
 


### PR DESCRIPTION
# タイトル
自作のlsコマンドに-lオプションを追加しました。

## 達成できる内容
- オプションなしで実行した場合はファイル名やディレクション名が３列で表示されます
- オプションで`-l`を指定したら、ファイルやディレクションの情報が横１列に表示されます

## 実行結果
<img width="496" alt="スクリーンショット 2024-02-15 11 51 55" src="https://github.com/funxxfun/ruby-practices/assets/86139603/c5ace3b0-752c-4fc7-8381-5c3aa445afa4">


## Rubocop
- [x] 実行済み
- [ ] 未実行
<img width="372" alt="スクリーンショット 2024-02-06 21 36 53" src="https://github.com/funxxfun/ruby-practices/assets/86139603/d50392d4-79c4-4287-b687-3105aa204911">

## その他
ご確認よろしくお願いします。