### PR TITLE
自作lsコマンドで、a、r、l全てのオプションを使用できるようにした

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -31,11 +31,17 @@ FILE_PERMISSION =
 
 def files(options, path = '.')
   opt = OptionParser.new
+  opt.on('-a') { |v| options[:a] = v }
   opt.on('-r') { |v| options[:r] = v }
   opt.on('-l') { |v| options[:l] = v }
   opt.parse!(ARGV)
 
-  files = Dir.entries(path).reject { |file| file.start_with?('.') }.sort
+  files = Dir.entries(path)
+  files = if options[:a]
+            files.sort
+          else
+            files.reject { |entry| entry.start_with?('.') }.sort
+          end
   files = files.reverse if options[:r]
   files
 end
@@ -83,8 +89,8 @@ def display_long_format(entries)
     file_size = file.size.to_s
     time_stamp = file.mtime.strftime('%-m %e %H:%M')
     puts "#{file_type}#{file_permissions} " \
-    "#{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} " \
-    "#{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
+         "#{file_nlink.rjust(2)} #{file_owner.rjust(6)} #{file_group.rjust(6)} " \
+         "#{file_size.rjust(5)} #{time_stamp.rjust(11)} #{entry}"
   end
 end
 


### PR DESCRIPTION
# タイトル
自作lsコマンドのオプション-a、-r、-lを併用できるようにした

## 達成できる内容
lsコマンド使用時にオプションを組み合わせて使用できるようになった

## 必須要件

## テスト結果
<img width="1093" alt="スクリーンショット 2024-02-16 8 11 59" src="https://github.com/funxxfun/ruby-practices/assets/86139603/f44f799b-de2f-4132-89d9-6a3e6ac122c2">
<img width="487" alt="スクリーンショット 2024-02-16 8 12 37" src="https://github.com/funxxfun/ruby-practices/assets/86139603/a1f237c0-04fb-4548-9480-f8062ba27e20">
<img width="1050" alt="スクリーンショット 2024-02-16 8 13 37" src="https://github.com/funxxfun/ruby-practices/assets/86139603/dd0d57c2-6e87-4d0f-9ba3-d7e947e24228">
<img width="481" alt="スクリーンショット 2024-02-16 8 14 47" src="https://github.com/funxxfun/ruby-practices/assets/86139603/fd98a8c1-c3d4-4487-9872-963d558a4444">
<img width="503" alt="スクリーンショット 2024-02-16 8 15 22" src="https://github.com/funxxfun/ruby-practices/assets/86139603/e615b409-bba8-4269-b56a-aa412ba143cf">
<img width="508" alt="スクリーンショット 2024-02-16 8 15 53" src="https://github.com/funxxfun/ruby-practices/assets/86139603/a9987e7a-e8ef-4517-b977-2666b664f14a">


## Rubocop
- [x] 実行済み
- [ ] 未実行
<img width="320" alt="スクリーンショット 2024-02-16 8 16 33" src="https://github.com/funxxfun/ruby-practices/assets/86139603/73885596-6ec2-41ef-b759-d389d0a9cfa9">

## その他
ご確認よろしくお願いします。